### PR TITLE
Added basic CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - 'lts/*'
+  - '8'
+  - '6'
+cache:
+  yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - 'lts/*'
   - '8'
-  - '6'
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 'lts/*'
+  - '10'
   - '8'
 cache:
   yarn: true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ yarn global add testemail
 
 ## Usage
 
+> note - this package support node >=8
+
 In terminal / cmd:
 
 ```bash
@@ -44,26 +46,6 @@ This will either:
 - Generate an aliased email instantly
 - Allow you to enter an email address to be aliased
 - Allow you to use the email address previously used
-
-## Tests
-
-All modules (anything other than `index.js`) should include unit tests. These are written using [jest](https://jestjs.io/).
-
-> **automock** - The option `automock` is set to `true` in the jest config of this library. This means any `require` statement will use the mock instead of the actual module. This can be overriden using `jest.unmock('./path-to-import.js')`.
-
-To run tests, in terminal / cmd:
-
-_With npm_
-
-```bash
-npm run test
-```
-
-_With Yarn_
-
-```bash
-yarn test
-```
 
 ## Advanced usage / configuration
 
@@ -89,3 +71,25 @@ An example of this file is:
 ```
 
 The location this file is stored can be configured with the optional `TEST_EMAIL_FILE` environment variable. This should be relative to root, e.g. `~/jon/Documents/email-file/my-test-email.json`.
+
+## Development
+
+### Tests
+
+All modules (anything other than `index.js`) should include unit tests. These are written using [jest](https://jestjs.io/).
+
+> **automock** - The option `automock` is set to `true` in the jest config of this library. This means any `require` statement will use the mock instead of the actual module. This can be overriden using `jest.unmock('./path-to-import.js')`.
+
+To run tests, in terminal / cmd:
+
+_With npm_
+
+```bash
+npm run test
+```
+
+_With Yarn_
+
+```bash
+yarn test
+```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "main": "src/index.js",
   "author": "Jon Short",
   "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  },
+  "engineStrict": true,
   "bin": "src/index.js",
   "files": [
     "src/**/*.js",


### PR DESCRIPTION
This PR adds a basic travis config to the project which runs all unit tests.

Travis targets node `8`, `10`, and `lts/*`

Closes #8 